### PR TITLE
TECH-453: Add "compatibility" field to the BB object (BE)

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "mongoose-gen": "^2.1.1",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^2.0.20",
+    "prettier": "^2.8.4",
     "streamifier": "^0.1.1"
   },
   "scripts": {

--- a/server/src/db/repositories/reportRepository.js
+++ b/server/src/db/repositories/reportRepository.js
@@ -12,7 +12,8 @@ function getLatestReportPipeline(filters) {
         sourceBranch: { $exists: 1 },
         saveTime: { $exists: 1 },
       },
-    }, {
+    },
+    {
       $group: {
         _id: {
           buildingBlock: '$buildingBlock',
@@ -22,7 +23,10 @@ function getLatestReportPipeline(filters) {
         },
         latest: {
           $last: {
-            date: '$finish.timestamp.seconds', saveTime: '$saveTime', id: '$_id', testCases: '$testCases',
+            date: '$finish.timestamp.seconds',
+            saveTime: '$saveTime',
+            id: '$_id',
+            testCases: '$testCases',
           },
         },
       },
@@ -61,6 +65,66 @@ function getLatestReportPipeline(filters) {
                   },
                 },
               },
+            },
+            compatibility: {
+              $let: {
+                vars: {
+                  sumPassed: {
+                    $size: {
+                      $filter: {
+                        input: '$latest.testCases',
+                        as: 'case',
+                        cond: {
+                          $eq: ['$$case.passed', true],
+                        },
+                      },
+                    },
+                  },
+                  sumFailed: {
+                    $size: {
+                      $filter: {
+                        input: '$latest.testCases',
+                        as: 'case',
+                        cond: {
+                          $eq: ['$$case.passed', false],
+                        },
+                      },
+                    },
+                  },
+                },
+                in: {
+                  $round: [
+                    {
+                      $divide: ['$$sumPassed', { $add: ['$$sumPassed', '$$sumFailed'] }],
+                    },
+                    4,
+                  ],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    {
+      $set: {
+        overallCompatibility: {
+          $let: {
+            vars: {
+              sumPassed: {
+                $sum: '$compatibilities.testsPassed',
+              },
+              sumFailed: {
+                $sum: '$compatibilities.testsFailed',
+              },
+            },
+            in: {
+              $round: [
+                {
+                  $divide: ['$$sumPassed', { $add: ['$$sumPassed', '$$sumFailed'] }],
+                },
+                4,
+              ],
             },
           },
         },

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -3429,6 +3429,11 @@ prelude-ls@~1.1.2:
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
   integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
 
+prettier@^2.8.4:
+  version "2.8.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.4.tgz#34dd2595629bfbb79d344ac4a91ff948694463c3"
+  integrity sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz"


### PR DESCRIPTION
Added 2 fields to the product object: compatibility and overallCompatibility.

**Example of the result**
![image](https://user-images.githubusercontent.com/119664031/222075891-086d39f8-1faa-4c44-aed0-df6de78fb625.png)

**Description**
We agreed that compatibility should be counted on BE.
A new field needs to be added to the product object:
- compatibility (for each building block )
- and overall compatibility

Acceptance criteria:
- each object in the array returned from BE should have 2 new fields (compatibility and overall compatibility)


TICKET: https://govstack-global.atlassian.net/browse/TECH-453