### PR TITLE
TECH-522:     TECH-271  TECH-522 Fix /report/count endpoint

### DIFF
--- a/server/src/routes/record.js
+++ b/server/src/routes/record.js
@@ -11,10 +11,10 @@ const buildReportRoutes = (reportController) => {
   reportRoutes
     .route('/report')
     .get(PaginationMiddleware.handlePaginationFilters, reportController.getProductCompatibility);
+  reportRoutes.route('/report/count').get(reportController.getProductsCount);
   reportRoutes
     .route('/report/:id')
     .get(PaginationMiddleware.handlePaginationFilters, reportController.getProductDetails);
-  reportRoutes.route('/report/count').get(reportController.getProductsCount);
   return reportRoutes;
 };
 


### PR DESCRIPTION
 Fixed /report/count endpoint

Description:
/report/count endpoints returns error message:

_Unexpected exception occurred: BSONTypeError: Argument passed in must be a string of 12 bytes or a string of 24 hex
characters or an integer_


Acceptance criteria

- /report/count endpoint works as expected
- should return : 

{
   "count": n
}


TICKET: https://govstack-global.atlassian.net/browse/TECH-522