### PR TITLE
TECH-519: Add gherkin scenarios steps data to report/:id endpoint (BE)

### DIFF
--- a/server/src/routes/record.js
+++ b/server/src/routes/record.js
@@ -11,10 +11,11 @@ const buildReportRoutes = (reportController) => {
   reportRoutes
     .route('/report')
     .get(PaginationMiddleware.handlePaginationFilters, reportController.getProductCompatibility);
+  reportRoutes.route('/report/count').get(reportController.getProductsCount);
   reportRoutes
     .route('/report/:id')
     .get(PaginationMiddleware.handlePaginationFilters, reportController.getProductDetails);
-  reportRoutes.route('/report/count').get(reportController.getProductsCount);
+
   return reportRoutes;
 };
 

--- a/server/src/useCases/report/productTestCases/handleGetProductDetailsRequest.js
+++ b/server/src/useCases/report/productTestCases/handleGetProductDetailsRequest.js
@@ -22,32 +22,16 @@ module.exports = class ReportGetProductDetailsRequestHandler {
 
       const aggregatedResult = result[0];
 
-      /*  reduce to one item per endpoint, where we always prefer
-      the ones that didn't pass over the ones that did  */
-      const aggregatedData = aggregatedResult.data.reduce((items, item) => {
-        const lastItemIndex = items.length - 1;
-        const lastItem = lastItemIndex < 0 ? null : items[lastItemIndex];
-
-        if (lastItem === null || item.uri !== lastItem.uri) {
-          // add new item
-          items.push(item);
-        } else if (!item.passed) {
-          // replace with the failed item
-          items[lastItemIndex] = item;
-        }
-
-        return items;
-      }, []);
-
       const paginatedAggregatedData = offset !== undefined
-        ? aggregatedData.slice(offset, limit + offset) : aggregatedData.slice(0, limit);
+        ? aggregatedResult.data.slice(offset, limit + offset)
+        : aggregatedResult.data.slice(0, limit);
 
       // build response object
       const finalResult = {};
       Object.assign(finalResult, {
         compatibilities: aggregatedResult.compatibilities,
         data: paginatedAggregatedData,
-        count: aggregatedData.length,
+        count: aggregatedResult.data.length,
       });
 
       this.res.json(finalResult);


### PR DESCRIPTION
Updated /report/:id endpoint to also return gherkin scenarios data. Removed reduce method from handler -> moved calculations from there to aggregation. 

```details``` example: 
![image](https://user-images.githubusercontent.com/119664031/228569333-ce97ae30-8458-4fe0-8ebe-403517fff787.png)

TICKET: https://govstack-global.atlassian.net/browse/TECH-519