### PR TITLE
Fix node_modules in docker dev setup 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-node_modules
 build
 .dockerignore
 Dockerfile

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,10 +3,12 @@ services:
   web:
     volumes:
       - .:/testing-webapp
+      - ./testing-webapp/node_modules
     ports:
       - 3003:3003
 
   backend:
-    volumes:
-      - ./server:/app
+      volumes:
+        - ./server:/app
+        - ./app/node_modules
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -8,7 +8,7 @@ services:
       - 3003:3003
 
   backend:
-      volumes:
-        - ./server:/app
-        - ./app/node_modules
+    volumes:
+      - ./server:/app
+      - ./app/node_modules
 

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,2 +1,1 @@
-node_modules
 npm-debug.log


### PR DESCRIPTION
Missing node modules cause failure of overridden docker setup (nodemon and next not ofund). 