### PR TITLE
TECH-456: Added META.yml

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 COPY . .
 
 RUN yarn install
+RUN yarn add nodemon
+RUN ls
 
 EXPOSE 5000
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/server/package.json
+++ b/server/package.json
@@ -9,6 +9,7 @@
     "dotenv": "^16.0.3",
     "eslint-config": "^0.3.0",
     "express": "^4.18.2",
+    "js-yaml": "^4.1.0",
     "jsonschema": "^1.4.1",
     "mongodb": "^4.13.0",
     "mongoose": "^6.9.1",

--- a/server/src/controllers/reportController.js
+++ b/server/src/controllers/reportController.js
@@ -7,7 +7,7 @@ const reportController = (reportDbRepository, reportDbRepositoryImpl) => {
   const repository = reportDbRepository(reportDbRepositoryImpl);
 
   const saveReport = (req, res) => {
-    if (!req.file) {
+    if (!req.files) {
       res.status(400).send('Invalid form, file not provided.');
       return;
     }

--- a/server/src/db/schemas/report.js
+++ b/server/src/db/schemas/report.js
@@ -83,8 +83,13 @@ const TestCase = {
   passed: Boolean,
 };
 
+const ProductMetaData = {
+  name: String,
+};
+
 const TestReportSchema = new mongoose.Schema({
   meta: MetaSchema,
+  productMetaData: ProductMetaData,
   start: {
     timestamp: TimeStamp,
   },

--- a/server/src/routes/record.js
+++ b/server/src/routes/record.js
@@ -7,7 +7,8 @@ const buildReportRoutes = (reportController) => {
 
   const storage = multer.memoryStorage();
   const upload = multer({ storage });
-  reportRoutes.route('/report/upload').post(upload.single('report'), reportController.saveReport);
+  const filesUpload = upload.fields([{ name: 'report', maxCount: 1 }, { name: 'META', maxCount: 1 }]);
+  reportRoutes.route('/report/upload').post(filesUpload, reportController.saveReport);
   reportRoutes
     .route('/report')
     .get(PaginationMiddleware.handlePaginationFilters, reportController.getProductCompatibility);

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -4207,7 +4207,7 @@ js-yaml@^3.13.1, js-yaml@^3.5.1:
 
 js-yaml@^4.1.0:
   version "4.1.0"
-  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.1.0.tgz#c1fb65f8f5017901cdd2c951864ba18458a10602"
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"


### PR DESCRIPTION
Part of [TECH-456](https://govstack-global.atlassian.net/browse/TECH-456)
Report upload was extended by additional META file field. 
It is not mandatory and content of newly created Report schema property `productMetaData` is replaced with artificial value baset on testApp value. 

[TECH-456]: https://govstack-global.atlassian.net/browse/TECH-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ