### PR TITLE
TECH-790: added versioning for test suite

### DIFF
--- a/__tests__/components/table/mockedData/ProductTable.ts
+++ b/__tests__/components/table/mockedData/ProductTable.ts
@@ -11,6 +11,7 @@ export const mockedProduct: ProductsType = {
     testApp: 'Test Product',
     testSuite: 'Test suite',
     sourceBranch: 'Test branch',
+    version: 'Version',
   },
   compatibilities: [
     {

--- a/server/src/db/schemas/report.js
+++ b/server/src/db/schemas/report.js
@@ -103,6 +103,7 @@ const TestReportSchema = new mongoose.Schema({
   testSuite: String,
   testApp: String,
   sourceBranch: String,
+  version: String,
 });
 
 TestReportSchema.index({
@@ -111,6 +112,7 @@ TestReportSchema.index({
   testSuite: 1,
   testApp: 1,
   sourceBranch: 1,
+  version: 1,
   saveTime: -1,
 });
 

--- a/server/src/useCases/report/productCompatibility/handleGetProductRequest.js
+++ b/server/src/useCases/report/productCompatibility/handleGetProductRequest.js
@@ -14,6 +14,7 @@ module.exports = class ReportGetProductRequestHandler {
       'sort.testApp': '_id.testApp',
       'sort.testSuite': '_id.testSuite',
       'sort.sourceBranch': '_id.sourceBranch',
+      'sort.version': '_id.version',
       'sort.overallCompatibility': 'overallCompatibility',
       'sort.lastUpdate': 'lastUpdate',
     };

--- a/server/src/useCases/report/reportSave/handleSaveRequest.js
+++ b/server/src/useCases/report/reportSave/handleSaveRequest.js
@@ -28,6 +28,7 @@ const RequestSchema = {
         testSuite: { type: 'string' },
         testApp: { type: 'string' },
         sourceBranch: { type: 'string' },
+        version: {type: 'string'},
       },
       required: [
         'buildingBlock',
@@ -168,6 +169,7 @@ module.exports = class ReportUploadRequestHandler {
     report.testSuite = this.req.body.testSuite;
     report.testApp = this.req.body.testApp;
     report.sourceBranch = this.req.body.sourceBranch;
+    report.version = this.req.body.version;
     report.productMetaData = productMetaData;
 
     this.saveToDatabase(repository, report);

--- a/service/types.ts
+++ b/service/types.ts
@@ -13,6 +13,7 @@ export type ProductsType = {
     testApp: string; // Label of the product
     testSuite: string; // Test suite label
     sourceBranch: string; // Branch on which tests were executed
+    version: string; // Version on which tests were executed
   };
   compatibilities: BuildingBlockType[];
   overallCompatibility: number;


### PR DESCRIPTION
Ticket
[TECH-790](https://govstack-global.atlassian.net/browse/TECH-790)

Test-utils PR:
https://github.com/GovStackWorkingGroup/test-utils/pull/9

Changes:
- added a version property to the report schema.

Testing Methodology:
- I have locally executed the tests for the bb-digital-registries project. All generated reports, based on the main branch, were successfully stored in the database. Additionally, each report now includes a version property that indicates the tag used.

[TECH-790]: https://govstack-global.atlassian.net/browse/TECH-790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ