### PR TITLE
TECH-891: Changed compliance detail pipeline to handle more version per bb

### DIFF
--- a/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
@@ -1,67 +1,108 @@
 export const softwareDetailAggregationPipeline = (softwareName: string): any[] => [
-    {
-      $match: { "softwareName": softwareName }
-    },
-    {
-      $unwind: "$compliance"
-    },
-    {
-      $project: {
-        softwareName: 1,
-        logo: 1,
-        website: 1,
-        documentation: 1,
-        pointOfContact: 1,
-        version: "$compliance.version",
-        bbDetails: {
-          $arrayToObject: {
-            $map: {
-              input: { $objectToArray: "$compliance.bbDetails" },
-              as: "bbDetail",
-              in: [
-                "$$bbDetail.k",
-                {
-                  bbVersion: "$$bbDetail.v.bbVersion",
-                  requirementSpecificationCompliance: {
-                    level: "$$bbDetail.v.requirementSpecificationCompliance.level",
-                    note: "$$bbDetail.v.requirementSpecificationCompliance.note"
-                  },
-                  interfaceCompliance: {
-                    level: "$$bbDetail.v.interfaceCompliance.level",
-                    note: "$$bbDetail.v.interfaceCompliance.note"
-                  }
-                }
-              ]
-            }
+  {
+    $match: { "softwareName": softwareName }
+  },
+  {
+    $unwind: "$compliance"
+  },
+  {
+    $addFields: {
+      "compliance.bbDetailsArray": {
+        $map: {
+          input: { $objectToArray: "$compliance.bbDetails" },
+          as: "detail",
+          in: {
+            "bbName": "$$detail.k",
+            "bbVersion": "$$detail.v.bbVersion",
+            "requirements": "$$detail.v.requirementSpecificationCompliance",
+            "interface": "$$detail.v.interfaceCompliance"
           }
         }
-      }
-    },
-    {
-      $group: {
-        _id: "$softwareName",
-        logo: { $first: "$logo" },
-        website: { $first: "$website" },
-        documentation: { $first: "$documentation" },
-        pointOfContact: { $first: "$pointOfContact" },
-        compliance: {
-          $push: {
-            formId: "$_id",
-            version: "$version",
-            bbDetails: "$bbDetails"
-          }
-        }
-      }
-    },
-    {
-      $project: {
-        _id: 0,
-        softwareName: "$_id",
-        logo: 1,
-        website: 1,
-        documentation: 1,
-        pointOfContact: 1,
-        compliance: 1
       }
     }
-  ];
+  },
+  {
+    $unwind: "$compliance.bbDetailsArray"
+  },
+  {
+    $group: {
+      _id: {
+        softwareName: "$softwareName",
+        version: "$compliance.version",
+        bbName: "$compliance.bbDetailsArray.bbName"
+      },
+      bbVersions: {
+        $push: {
+          bbVersion: "$compliance.bbDetailsArray.bbVersion",
+          requirements: "$compliance.bbDetailsArray.requirements",
+          interface: "$compliance.bbDetailsArray.interface"
+        }
+      },
+      // Add these fields to be used with $first in the final $group stage
+      logo: { $first: "$logo" },
+      website: { $first: "$website" },
+      documentation: { $first: "$documentation" },
+      pointOfContact: { $first: "$pointOfContact" }
+    }
+  },
+  {
+    $group: {
+      _id: {
+        softwareName: "$_id.softwareName",
+        version: "$_id.version"
+      },
+      bbDetails: {
+        $push: {
+          bbName: "$_id.bbName",
+          bbVersions: "$bbVersions"
+        }
+      },
+      // Keep carrying these fields
+      logo: { $first: "$logo" },
+      website: { $first: "$website" },
+      documentation: { $first: "$documentation" },
+      pointOfContact: { $first: "$pointOfContact" }
+    }
+  },
+  {
+    $project: {
+      softwareVersion: "$_id.version",
+      bbDetails: 1,
+      // Include these fields in the projection
+      logo: 1,
+      website: 1,
+      documentation: 1,
+      pointOfContact: 1
+    }
+  },
+  {
+    $sort: { "softwareVersion": 1 } // Assuming you want it sorted by version
+  },
+  {
+    $group: {
+      _id: "$_id.softwareName",
+      compliance: {
+        $push: {
+          softwareVersion: "$softwareVersion",
+          bbDetails: "$bbDetails"
+        }
+      },
+      // Use $first to get the fields from the grouped documents
+      logo: { $first: "$logo" },
+      website: { $first: "$website" },
+      documentation: { $first: "$documentation" },
+      pointOfContact: { $first: "$pointOfContact" }
+    }
+  },
+  {
+    $project: {
+      _id: 0,
+      softwareName: "$_id",
+      logo: 1,
+      website: 1,
+      documentation: 1,
+      pointOfContact: 1,
+      compliance: 1
+    }
+  }
+];


### PR DESCRIPTION
**Changes:**
The pipeline for the aggregation of compliance form details has been modified within the scope of this ticket to accommodate multiple versions per building block without encountering key errors.

**New format of returned data:**
```
{
        "logo": str,
        "website": str,
        "documentation": str,
        "pointOfContact": str,
        "softwareName": str
compliance: [
{	
	softwareVersion: "1.0"
	bbDetails: [	
		{ bbName1: "bb-payments"
		bbVersions: [
			bbVersion: 1.1 bbDetail: {requirements, interface}
			bbVersion: 1.2 bbDetail: {requirements, interface}
			bbVersion: 2.1 bbDetail: {requirements, interface}
		]},
		{ bbName1: "bb-digital-registries"
		bbVersions: [
			bbVersion: 1.1 bbDetail: {requirements, interface}
			bbVersion: 1.2 bbDetail: {requirements, interface}
			bbVersion: 2.1 bbDetail: {requirements, interface}
		]},
		{ bbName1: "bb-consent"
		bbVersions: [
			bbVersion: 1.1 bbDetail: {requirements, interface}
			bbVersion: 1.2 bbDetail: {requirements, interface}
			bbVersion: 2.1 bbDetail: {requirements, interface}
		]},
		
]},
```

**Example of returned data:**
[responseComplianceDetails9.11.2023.json](https://github.com/GovStackWorkingGroup/testing-webapp/files/13306287/responseComplianceDetails9.11.2023.json)
