### PR TITLE
TECH-901: changed Jira ticket creation, extended template

### DIFF
--- a/backend/@types/index.d.ts
+++ b/backend/@types/index.d.ts
@@ -27,7 +27,9 @@ declare module 'myTypes' {
     status: number,
     uniqueId: string | undefined,
     expirationDate: Date | undefined,
-    id: ObjectId
+    id: ObjectId,
+    softwareName: string,
+    bbKeys: string[]
   }
 
   export interface ComplianceDetail {

--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -17,6 +17,7 @@ interface AppConfig {
   draftExpirationTime: number,
   jira: {
     apiEndpoint: string;
+    domain: string;
     apiKey: string;
     email: string;
     projectKey: string;
@@ -61,6 +62,7 @@ const appConfig: AppConfig = {
   draftExpirationTime: 7 * 24 * 60 * 60 * 1000, // 7 days
   jira: {
     apiEndpoint: process.env.JIRA_API_ENDPOINT!,
+    domain: process.env.JIRA_API_DOMAIN!,
     apiKey: process.env.JIRA_API_KEY!,
     projectKey: process.env.JIRA_PROJECT_KEY!,
     email: process.env.JIRA_USER_EMAIL!,

--- a/backend/src/db/repositories/complianceRepository.ts
+++ b/backend/src/db/repositories/complianceRepository.ts
@@ -140,17 +140,23 @@ const mongoComplianceRepository: ComplianceDbRepository = {
       }
 
       if (errors.length === 0) {
+        // fetch bb keys
+        let bbKeys: string[] = [];
+        form.compliance.forEach(complianceItem => bbKeys.push(...Array.from(complianceItem.bbDetails.keys())));
         // save oryginal data for rollback
         originalData = {
           status: form.status,
           uniqueId: form.uniqueId,
           expirationDate: form.expirationDate,
-          id: form._id
+          id: form._id,
+          softwareName: form.softwareName,
+          bbKeys: bbKeys
         };
 
-        form.status = StatusEnum.IN_REVIEW;
-        form.uniqueId = undefined;
-        form.expirationDate = undefined;
+        await Compliance.updateOne({ _id: form._id }, {
+          $set: { status: StatusEnum.IN_REVIEW },
+          $unset: { uniqueId: "", expirationDate: "" }
+        });
 
         await form.save();
       }

--- a/backend/src/useCases/compliance/handleSubmitForm.ts
+++ b/backend/src/useCases/compliance/handleSubmitForm.ts
@@ -39,7 +39,10 @@ export default class SubmitFormRequestHandler {
 
             // Create Jira ticket only if integration is enabled
             if (appConfig.enableJiraIntegration) {
-                jiraTicketResult = await this.createJiraTicket();
+                jiraTicketResult = await this.createJiraTicket(
+                    draftDataForRollback.softwareName,
+                    draftDataForRollback.bbKeys
+                );
                 if (jiraTicketResult instanceof Error) {
                     throw jiraTicketResult;
                 }
@@ -66,31 +69,70 @@ export default class SubmitFormRequestHandler {
         }
     }
 
-    async createJiraTicket(): Promise<string | Error> {
+    async createJiraTicket(softwareName: string, buildingBlocks): Promise<string | Error> {
         const jiraConfig = appConfig.jira;
-        const descriptionText = jiraConfig.descriptionTemplate.replace('{{submitter}}', 'Submitter Name');
+        const formFullPath = this.getFrontendUrl(`/softwareRequirementsCompliance/details/`, softwareName);
+        const buildingBlocksArray = Array.isArray(buildingBlocks) ? buildingBlocks : buildingBlocks.split(',');
+
+        // Create bulleted list for building blocks
+        const buildingBlocksList = buildingBlocksArray.map(bb => ({
+            type: 'listItem',
+            content: [{
+                type: 'paragraph',
+                content: [{
+                    type: 'text',
+                    text: bb.trim(),
+                }]
+            }]
+        }));
+
         const descriptionADF = {
-            type: "doc",
-            version: 1,
-            content: [
-                {
-                    type: "paragraph",
-                    content: [
-                        {
-                            text: descriptionText,
-                            type: "text"
-                        }
-                    ]
-                }
-            ]
-        };
+        type: "doc",
+        version: 1,
+        content: [
+            {
+                type: "paragraph",
+                content: [
+                    {
+                        text: `${softwareName} has submitted a self-assessment for `,
+                        type: "text"
+                    }
+                ]
+            },
+            {
+                type: 'bulletList',
+                content: buildingBlocksList
+            },
+            {
+                type: "paragraph",
+                content: [
+                    {
+                        text: 'View the submission at ',
+                        type: 'text'
+                    },
+                    {
+                        type: 'text',
+                        text: formFullPath,
+                        marks: [
+                            {
+                                type: 'link',
+                                attrs: {
+                                    href: formFullPath
+                                }
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    };
 
         const payload = {
             fields: {
                 project: {
                     key: jiraConfig.projectKey,
                 },
-                summary: jiraConfig.titleTemplate.replace('{{form_title}}', 'Your Form Title'),
+                summary: jiraConfig.titleTemplate.replace('{{software_name}}', softwareName),
                 description: descriptionADF,
                 issuetype: {
                     name: jiraConfig.issueType,
@@ -103,15 +145,32 @@ export default class SubmitFormRequestHandler {
         try {
             const response = await axios.post(jiraConfig.apiEndpoint, payload, {
                 headers: {
-                    'Authorization': `Basic ${Buffer.from(`kolinoks@gmail.com:${jiraConfig.apiKey}`).toString('base64')}`,
+                    'Authorization': `Basic ${Buffer.from(`${jiraConfig.email}:${jiraConfig.apiKey}`).toString('base64')}`,
                     'Content-Type': 'application/json',
                 },
             });
+            // Extract the issue key from the response
+    const issueKey = response.data.key; // Assuming 'key' is the correct field
 
-            return response.data.self;
+    // Construct the browse URL
+    const browseUrl = `https://${jiraConfig.domain}/browse/${issueKey}`;
+
+    return browseUrl;
         } catch (error: any) {
             console.error('Failed to create Jira ticket:', error.response ? error.response.data : error);
             return new JiraTicketCreationError('Failed to create Jira ticket');
         }
+    }
+
+    private getFrontendUrl(path: string, softwareName: string): string {
+        let host = this.req.get('host');
+        const softwareNameForURL = softwareName.replace(' ', '%20');
+
+        if (host?.startsWith('api.')) {
+            host = host.substring(4); // delete 'api.' from URL
+        }
+
+        let baseUrl = `${this.req.protocol}://${host}`;
+        return `${baseUrl}${path}${softwareNameForURL}`;
     }
 }

--- a/backend/src/useCases/compliance/handleSubmitForm.ts
+++ b/backend/src/useCases/compliance/handleSubmitForm.ts
@@ -137,9 +137,9 @@ export default class SubmitFormRequestHandler {
                 issuetype: {
                     name: jiraConfig.issueType,
                 },
-                assignee: {
-                    id: jiraConfig.assigneeId,
-                }
+                // assignee: {
+                //     id: jiraConfig.assigneeId,
+                // }
             },
         };
         try {


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-901

Changes:
- changed Jira ticket creation to present this pattern:
```
SPACE - we’ll keep these in the TECH project for now
LABEL - create a new label called ‘Compliance’
ASSIGNEE - @Nico
TITLE - Compliance Form Submitted for <Product Name>
DESCRIPTION - <Product Name> has submitted a self-assessment for <Building Blocks>. View the submission at <Link to form in the testing harness>
Let me know if any of the data that I am suggesting here is not available to embed in the ticket. 
```
- fixed generated link for Jira TIcket