### PR TITLE
TECH-1040: Key Digital Functionalities are fetched from gitbook api

### DIFF
--- a/backend/@types/index.d.ts
+++ b/backend/@types/index.d.ts
@@ -112,6 +112,7 @@ declare module 'myTypes' {
     requirementSpecificationCompliance: {
       crossCuttingRequirements: Requirement[];
       functionalRequirements: Requirement[];
+      keyDigitalFunctionalities: Requirement[];
     };
     deploymentCompliance: {
       documentation: {
@@ -148,6 +149,7 @@ declare module 'myTypes' {
     requirements: {
       crossCutting: Requirement[];
       functional: Requirement[];
+      keyDigitalFunctionalities: Requirement[];
     }
   }
 

--- a/backend/src/db/pipelines/compliance/AllbbRequirements.ts
+++ b/backend/src/db/pipelines/compliance/AllbbRequirements.ts
@@ -28,6 +28,7 @@ export const aggregationPipeline = (): any[] => [
           crossCutting: "$requirements.crossCutting",
           functional: "$requirements.functional",
           interface: "$requirements.interface",
+          keyDigitalFunctionalities: "$requirements.keyDigitalFunctionalities"
         }
       }
     }

--- a/backend/src/db/pipelines/compliance/draftDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/draftDetailAggregation.ts
@@ -46,7 +46,8 @@ export const draftDetailAggregationPipeline = (draftUuid: string): any[] => {
                                             },
                                             requirementSpecificationCompliance: {
                                                 crossCuttingRequirements: "$$bbDetail.v.requirementSpecificationCompliance.crossCuttingRequirements",
-                                                functionalRequirements: "$$bbDetail.v.requirementSpecificationCompliance.functionalRequirements"
+                                                functionalRequirements: "$$bbDetail.v.requirementSpecificationCompliance.functionalRequirements",
+                                                keyDigitalFunctionalities: "$$bbDetail.v.requirementSpecificationCompliance.keyDigitalFunctionalities",
                                             },
                                             deploymentCompliance: "$$bbDetail.v.deploymentCompliance"
                                         }

--- a/backend/src/db/pipelines/compliance/formDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/formDetailAggregation.ts
@@ -35,7 +35,8 @@ export const formDetailAggregationPipeline = ({ formId, draftUuid }: {
                   },
                   requirementSpecificationCompliance: {
                     crossCuttingRequirements: "$$bbDetail.v.requirementSpecificationCompliance.crossCuttingRequirements",
-                    functionalRequirements: "$$bbDetail.v.requirementSpecificationCompliance.functionalRequirements"
+                    functionalRequirements: "$$bbDetail.v.requirementSpecificationCompliance.functionalRequirements",
+                    keyDigitalFunctionalities: "$$bbDetail.v.requirementSpecificationCompliance.keyDigitalFunctionalities",
                   }
                 }
               ]

--- a/backend/src/db/schemas/bbRequirements.ts
+++ b/backend/src/db/schemas/bbRequirements.ts
@@ -21,6 +21,7 @@ const BBRequirementSchema = new mongoose.Schema({
     },
     requirements: {
         crossCutting: [RequirementSchema],
+        keyDigitalFunctionalities: [RequirementSchema],
         functional: [RequirementSchema],
         interface: [RequirementSchema],
     }

--- a/backend/src/db/schemas/compliance/compliance.ts
+++ b/backend/src/db/schemas/compliance/compliance.ts
@@ -70,6 +70,10 @@ const requirementSpecificationComplianceSchema = new mongoose.Schema({
     type: [RequirementSchema],
     default: [],
   },
+  keyDigitalFunctionalities: {
+    type: [RequirementSchema],
+    default: [],
+  },
   notes: {
     type: String,
     default: ''

--- a/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
+++ b/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
@@ -1,0 +1,111 @@
+class GitBookPageManagerError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = 'GitBookPageManagerError';
+    }
+}
+
+class KeyDigitalFunctionalitiesExtractor {
+    extractKeyDigitalFunctionalitiesRequirements(pageContent: any) {
+        if (!pageContent?.document?.nodes) {
+            return { error: new GitBookPageManagerError("Invalid page content format.") };
+        }
+
+        const requirements: { status: number; requirement: string }[] = [];
+        const nodes: any[] = pageContent.document.nodes;
+
+        nodes.forEach((node, index) => {
+            if (this.isRelevantHeading(node, '4.')) {
+                this.processHeadingAndSubHeadings(nodes, index, requirements);
+            }
+        });
+
+        return { requirements };
+    }
+
+    private isRelevantHeading(node: any, prefix: string): boolean {
+        if (node.type && node.type.startsWith('heading-')) {
+            const headingText = this.extractTextFromNodeKDF(node);
+            return headingText.startsWith(prefix);
+        }
+        return false;
+    }
+
+    private processHeadingAndSubHeadings(nodes: any[], startIndex: number, requirements: { status: number; requirement: string }[]) {
+        const { headingText, currentHeadingLevel, contentUnderHeading } = this.initializeHeadingProcessing(nodes, startIndex);
+
+        let index = startIndex + 1;
+        let hasList = false;
+
+        while (index < nodes.length) {
+            const node = nodes[index];
+            if (this.isNewSection(node, currentHeadingLevel)) break;
+
+            if (this.isRelevantHeading(node, '4.')) {
+                this.processHeadingAndSubHeadings(nodes, index, requirements);
+                index++;
+                continue;
+            }
+
+            if (this.isListNode(node.type)) {
+                hasList = true;
+                this.processListNode(node, requirements);
+            } else if (!hasList) {
+                contentUnderHeading.push(this.extractTextFromNodeKDF(node));
+            }
+
+            index++;
+        }
+
+        if (!hasList && contentUnderHeading.length > 0) {
+            requirements.push({ status: 0, requirement: contentUnderHeading.join(' ').trim() });
+        }
+    }
+
+    private initializeHeadingProcessing(nodes: any[], startIndex: number) {
+        const headingText = this.extractTextFromNodeKDF(nodes[startIndex]);
+        const currentHeadingLevel = this.getHeadingLevel(headingText);
+        const contentUnderHeading: string[] = [];
+
+        return { headingText, currentHeadingLevel, contentUnderHeading };
+    }
+
+    private isNewSection(node: any, currentHeadingLevel: number): boolean {
+        if (node.type && node.type.startsWith('heading-')) {
+            const nextHeadingLevel = this.getHeadingLevel(this.extractTextFromNodeKDF(node));
+            return nextHeadingLevel <= currentHeadingLevel;
+        }
+        return false;
+    }
+
+    private getHeadingLevel(headingText: string): number {
+        const match = headingText.match(/^(\d+(\.\d+)*).*/);
+        return match ? match[1].split('.').length : 0;
+    }
+
+    private processListNode(node: any, requirements: { status: number; requirement: string }[]) {
+        if (node.nodes) {
+            node.nodes.forEach((item: any) => {
+                const itemText = this.extractTextFromNodeKDF(item);
+                if (itemText.trim()) {
+                    requirements.push({ status: 0, requirement: itemText.trim() });
+                }
+            });
+        }
+    }
+
+    private extractTextFromNodeKDF(node: any): string {
+        if (node.object === 'text') {
+            return node.leaves.map((leaf: any) => leaf.text).join(' ').trim();
+        } else if (node.object === 'block' || node.object === 'inline') {
+            return node.nodes.map((innerNode: any) => this.extractTextFromNodeKDF(innerNode)).join(' ').trim();
+        }
+        return '';
+    }
+
+    private isListNode(type: string): boolean {
+        return ['list-unordered', 'list-ordered'].includes(type);
+    }
+}
+
+export default KeyDigitalFunctionalitiesExtractor;

--- a/backend/src/services/gitBookService/PageContentManager.ts
+++ b/backend/src/services/gitBookService/PageContentManager.ts
@@ -1,4 +1,5 @@
 import { RequirementStatusEnum } from "myTypes";
+import KeyDigitalFunctionalitiesExtractor from "./KeyDigitalFunctionalitiesExtractor";
 
 type Requirement = {
     status: RequirementStatusEnum;
@@ -16,6 +17,12 @@ class GitBookPageContentManager {
     static REQUIRED_TEXT = "(REQUIRED)";
     static RECOMMENDED_TEXT = "(RECOMMENDED)";
     static OPTIONAL_TEXT = "(OPTIONAL)";
+
+    private kdfExtractor: KeyDigitalFunctionalitiesExtractor;
+
+    constructor() {
+        this.kdfExtractor = new KeyDigitalFunctionalitiesExtractor();
+    }
 
     extractInterfaceRequirements(documentObject, _) {
         if (!documentObject.pages || !Array.isArray(documentObject.pages)) {
@@ -99,6 +106,10 @@ class GitBookPageContentManager {
         });
 
         return { requirements };
+    }
+
+    extractKeyDigitalFunctionalitiesRequirements(pageContent: any) {
+        return this.kdfExtractor.extractKeyDigitalFunctionalitiesRequirements(pageContent);
     }
 
     extractTextFromNode(node) {

--- a/backend/src/services/gitBookService/bbRequirementsProcessing.ts
+++ b/backend/src/services/gitBookService/bbRequirementsProcessing.ts
@@ -11,6 +11,7 @@ const processBBRequirements = async () => {
     const CROSS_CUTTING_REQUIREMENTS_REGEX = /cross[\s-]?cutting[\s-]?requirements/i;
     const FUNCTIONAL_REQUIREMENTS_REGEX = /functional[\s-]?requirements/i;
     const INTERFACE_REQUIREMENTS_REGEX = /Architecture[\s-]?and[\s-]?Nonfunctional[\s-]?Requirements/i;
+    const KEY_DIGITAL_FUNCTIONALITIES_REQUIREMENTS_REGEX = /key[\s-]?digital[\s-]?functionalities/i;
 
     let errors: string[] = [];
 
@@ -24,6 +25,8 @@ const processBBRequirements = async () => {
                     extractResult = pageContentManager.extractCrossCuttingRequirements(pageContent, null);
                 } else if (pageTypeRegex === FUNCTIONAL_REQUIREMENTS_REGEX) {
                     extractResult = pageContentManager.extractFunctionalRequirements(pageContent);
+                } else if (pageTypeRegex === KEY_DIGITAL_FUNCTIONALITIES_REQUIREMENTS_REGEX) {
+                    extractResult = pageContentManager.extractKeyDigitalFunctionalitiesRequirements(pageContent);
                 }
 
                 if (extractResult.error) {
@@ -75,7 +78,8 @@ const processBBRequirements = async () => {
 
                 const crossCutting = await processPages(spaceInfo, CROSS_CUTTING_REQUIREMENTS_REGEX);
                 const functional = await processPages(spaceInfo, FUNCTIONAL_REQUIREMENTS_REGEX);
-                const requirements = { crossCutting, functional, interface: architecturalRequirements.requirements };
+                const keyDigitalFunctionalities = await processPages(spaceInfo, KEY_DIGITAL_FUNCTIONALITIES_REQUIREMENTS_REGEX);
+                const requirements = { crossCutting, functional, keyDigitalFunctionalities, interface: architecturalRequirements.requirements };
                 const dateOfSave = new Date().toISOString();
                 const bbRequirement = new BBRequirements({ bbKey, bbName, bbVersion: spaceInfo.version, dateOfSave, requirements });
                 await BBRequirements.deleteMany({ bbKey, bbName, bbVersion: spaceInfo.version });


### PR DESCRIPTION
**Ticket:**
https://govstack-global.atlassian.net/browse/TECH-1040

**Changes:**
- Key Digital Functionalities are fetched with functional and interface requirements when cron job is ran
- class PageContentManager is extended with new module designed for KDF
- KDF is added to GET FORM/DRAFT endpoint
- KDF is added to EDIT DRAFT endpoint
- KDF is fetched from each BB on gitbookapi with this approach:
```
1. Process Top-Level Headings:
1.1 The code starts by iterating through the nodes in the document.
1.2 If it encounters a heading that starts with "4." (e.g., "4.2 Core Services"), it processes this heading.

2. Handling Sections without Sub-Headers:
2.1 If a section does not contain any sub-headers but contains paragraphs or other text nodes, the entire section text is captured as a single requirement.
2.2 Example: If "4.2 Core Services" does not have any sub-headers and contains text, the entire text is saved as a single requirement.

3. Handling Lists:
3.1 If the section contains a list (ordered or unordered), each list item is extracted and saved as an individual requirement.
3.2 Example: For a list under "4.2 Core Services", each list item will be saved as a separate requirement.

4. Handling Sub-Headers:
4.1 If the section contains sub-headers (e.g., "4.2.1 Identity Usage"), the code recursively processes these sub-headers.
4.2 Sub-headers are treated as new heading nodes, and their content is processed similarly.
4.3 The text under the main heading that precedes sub-headers is not saved as a requirement; only the text directly under sub-headers is saved.

5. Stopping Condition for Same or Higher Level Headings:
5.1 When processing sub-headers, if a new heading of the same level or a higher level is encountered, processing stops for the current section.
5.2 This ensures that the content under different headings does not get mixed up.
```

**How was it tested?**
1. Endpoint for tests was created to ensure that KDF is visible and saved in the database. It was tested against three BB: identity, digital registries and consent. Each requirement was verified manually.

2. It was tested for each bb available on gitbook api and 12 bb were returned along with correct requirements, example of one bb:
![Screenshot from 2024-06-11 14-55-15](https://github.com/GovStackWorkingGroup/testing-webapp/assets/56487722/1dc496b7-e9cc-454d-8a58-49511ba7fdd6)


