### PR TITLE
feature/TECH-1054: consistent display of bb and description for each form

### DIFF
--- a/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
@@ -56,7 +56,8 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
       website: { $first: "$website" },
       documentation: { $first: "$documentation" },
       pointOfContact: { $first: "$pointOfContact" },
-      status: { $first: "$status" }
+      status: { $first: "$status" },
+      objectId: { $first: "$objectId" }
     }
   },
   {
@@ -75,7 +76,8 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
       website: { $first: "$website" },
       documentation: { $first: "$documentation" },
       pointOfContact: { $first: "$pointOfContact" },
-      status: { $first: "$status" }
+      status: { $first: "$status" },
+      objectId: { $first: "$objectId" }
     }
   },
   {
@@ -84,7 +86,8 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
       compliance: {
         $push: {
           softwareVersion: "$_id.softwareVersion",
-          bbDetails: "$bbDetails"
+          bbDetails: "$bbDetails",
+          _id: "$objectId" // Add _id at the same level as softwareVersion
         }
       },
       logo: { $first: "$logo" },

--- a/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
@@ -101,6 +101,9 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
     }
   },
   {
+    $sort: { _id: -1 } // Sort documents by their _id in descending order
+  },
+  {
     $project: {
       _id: 0,
       softwareName: "$_id",

--- a/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
@@ -1,6 +1,6 @@
 export const softwareDetailAggregationPipeline = (softwareName: string): any[] => [
   {
-    $match: { "softwareName": softwareName }
+    $match: { softwareName }
   },
   {
     $project: {
@@ -28,7 +28,7 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
             "bbVersion": "$$detail.v.bbVersion",
             "requirements": "$$detail.v.requirementSpecificationCompliance",
             "interface": "$$detail.v.interfaceCompliance",
-            "deploymentCompliance": "$$detail.v.deploymentCompliance" 
+            "deploymentCompliance": "$$detail.v.deploymentCompliance"
           }
         }
       }
@@ -40,9 +40,8 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
   {
     $group: {
       _id: {
-        objectId: "$objectId",
         softwareName: "$softwareName",
-        version: "$compliance.version",
+        softwareVersion: "$compliance.version",
         bbName: "$compliance.bbDetailsArray.bbName"
       },
       bbVersions: {
@@ -63,9 +62,8 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
   {
     $group: {
       _id: {
-        objectId: "$_id.objectId",
         softwareName: "$_id.softwareName",
-        version: "$_id.version"
+        softwareVersion: "$_id.softwareVersion"
       },
       bbDetails: {
         $push: {
@@ -81,27 +79,11 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
     }
   },
   {
-    $project: {
-      objectId: "$_id.objectId",
-      softwareVersion: "$_id.version",
-      bbDetails: 1,
-      logo: 1,
-      website: 1,
-      documentation: 1,
-      pointOfContact: 1,
-      status: 1
-    }
-  },
-  {
-    $sort: { "softwareVersion": 1 } // Sorting by version
-  },
-  {
     $group: {
-      _id: "$objectId",
-      softwareName: { $first: "$_id.softwareName" },
+      _id: "$_id.softwareName",
       compliance: {
         $push: {
-          softwareVersion: "$softwareVersion",
+          softwareVersion: "$_id.softwareVersion",
           bbDetails: "$bbDetails"
         }
       },
@@ -114,15 +96,17 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
   },
   {
     $project: {
-      _id: 1,
-      softwareName: 1,
+      _id: 0,
+      softwareName: "$_id",
+      compliance: 1,
       logo: 1,
       website: 1,
       documentation: 1,
       pointOfContact: 1,
-      compliance: 1,
-      deploymentCompliance: 1,
       status: 1
     }
+  },
+  {
+    $limit: 1 // Return the first matching object
   }
 ];

--- a/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
+++ b/backend/src/db/pipelines/compliance/softwareDetailAggregation.ts
@@ -3,6 +3,9 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
     $match: { softwareName }
   },
   {
+    $sort: { _id: -1 } // Sort documents by their _id in descending order
+  },
+  {
     $project: {
       objectId: "$_id", // Use the actual _id field from the document
       softwareName: 1,
@@ -110,6 +113,6 @@ export const softwareDetailAggregationPipeline = (softwareName: string): any[] =
     }
   },
   {
-    $limit: 1 // Return the first matching object
+    $limit: 1 // Return the latest matching object
   }
 ];

--- a/frontend/components/compliance/SoftwareDetails.tsx
+++ b/frontend/components/compliance/SoftwareDetails.tsx
@@ -26,9 +26,6 @@ const SoftwareDetails = ({
   redirectToStep,
   viewReportDetails,
 }: SoftwareDetailsProps) => {
-
-  console.log("ID", softwareId);
-
   const { format } = useTranslations();
   const router = useRouter();
 

--- a/frontend/components/compliance/SoftwareDetails.tsx
+++ b/frontend/components/compliance/SoftwareDetails.tsx
@@ -26,6 +26,9 @@ const SoftwareDetails = ({
   redirectToStep,
   viewReportDetails,
 }: SoftwareDetailsProps) => {
+
+  console.log("ID", softwareId);
+
   const { format } = useTranslations();
   const router = useRouter();
 

--- a/frontend/pages/requirements/details/[softwareName]/index.tsx
+++ b/frontend/pages/requirements/details/[softwareName]/index.tsx
@@ -65,6 +65,7 @@ const SoftwareComplianceDetailsPage = () => {
   }, [softwareDetail]);
 
   const fetchData = async (softwareName: string) => {
+    console.log("fetchData");
     const data = await getSoftwareDetails(softwareName);
     if (data.status) {
       setSoftwareDetail(data.data);
@@ -237,34 +238,35 @@ const SoftwareComplianceDetailsPage = () => {
           </div>
         )}
         {softwareDetail.length && softwareDetail[0].compliance.length
-          ? softwareDetail[0].compliance.map((item, indexKey) => (
-            <SoftwareDetails
-              title={format('app.compliance_with.label')}
-              complianceSection={true}
-              softwareVersion={item.softwareVersion}
-              softwareId={softwareDetail[0]._id}
-              key={`software-compliance-with-${indexKey}`}
-              viewReportDetails={true}
-            >
-              {isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1 ? (
-                <ComplianceDetailTable
-                  data={softwareDetailsDataToApprove}
-                  handleOpenEvaluationSchemaModal={(value) =>
-                    setDisplayEvaluationSchemaModal(value)
-                  }
-                  setUpdatedData={(data) => {
-                    setUpdatedData(data);
-                    setIsFormSaved(false);
-                  }}
-                />
-              ) : (
-                <SoftwareComplianceWith
-                  softwareComplianceData={item.bbDetails}
-                />
-              )}
-            </SoftwareDetails>
-          ))
-          : null}
+        ? softwareDetail[0].compliance.map((item, indexKey) => (
+          <SoftwareDetails
+            title={format('app.compliance_with.label')}
+            complianceSection={true}
+            softwareVersion={item.softwareVersion}
+            softwareId={softwareDetail[0].compliance[indexKey]._id} // Pass the correct ID for each compliance item
+            key={`software-compliance-with-${indexKey}`}
+            viewReportDetails={true}
+          >
+            {isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1 ? (
+              <ComplianceDetailTable
+                data={softwareDetailsDataToApprove}
+                handleOpenEvaluationSchemaModal={(value) =>
+                  setDisplayEvaluationSchemaModal(value)
+                }
+                setUpdatedData={(data) => {
+                  setUpdatedData(data);
+                  setIsFormSaved(false);
+                }}
+              />
+            ) : (
+              <SoftwareComplianceWith
+                softwareComplianceData={item.bbDetails}
+              />
+            )}
+          </SoftwareDetails>
+        ))
+        : null}
+
       </div>
       {(isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1) &&
         <div className="bottom-bar-container">

--- a/frontend/pages/requirements/details/[softwareName]/index.tsx
+++ b/frontend/pages/requirements/details/[softwareName]/index.tsx
@@ -65,7 +65,6 @@ const SoftwareComplianceDetailsPage = () => {
   }, [softwareDetail]);
 
   const fetchData = async (softwareName: string) => {
-    console.log("fetchData");
     const data = await getSoftwareDetails(softwareName);
     if (data.status) {
       setSoftwareDetail(data.data);

--- a/frontend/pages/requirements/details/[softwareName]/index.tsx
+++ b/frontend/pages/requirements/details/[softwareName]/index.tsx
@@ -83,12 +83,12 @@ const SoftwareComplianceDetailsPage = () => {
   ) => {
     const { name, value } = event.target;
 
-    if (name === 'softwareName' ) {
+    if (name === 'softwareName') {
       setDeleteSoftwareName(value);
     }
   };
 
-  const handleDeleteEntry = async() => {
+  const handleDeleteEntry = async () => {
     if (deleteSoftwareName === softwareName) {
       await handleDeleteSoftwareForm(softwareDetail[0]._id).then(
         (response) => {
@@ -218,7 +218,7 @@ const SoftwareComplianceDetailsPage = () => {
             showContactDetails={true}
           />
         </SoftwareDetails>
-        { isLoggedIn && (
+        {isLoggedIn && (
           <div className="software-attributes-section">
             <Input
               name="softwareName"
@@ -237,34 +237,34 @@ const SoftwareComplianceDetailsPage = () => {
           </div>
         )}
         {softwareDetail.length && softwareDetail[0].compliance.length
-        ? softwareDetail[0].compliance.map((item, indexKey) => (
-          <SoftwareDetails
-            title={format('app.compliance_with.label')}
-            complianceSection={true}
-            softwareVersion={item.softwareVersion}
-            softwareId={softwareDetail[0].compliance[indexKey]._id} // Pass the correct ID for each compliance item
-            key={`software-compliance-with-${indexKey}`}
-            viewReportDetails={true}
-          >
-            {isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1 ? (
-              <ComplianceDetailTable
-                data={softwareDetailsDataToApprove}
-                handleOpenEvaluationSchemaModal={(value) =>
-                  setDisplayEvaluationSchemaModal(value)
-                }
-                setUpdatedData={(data) => {
-                  setUpdatedData(data);
-                  setIsFormSaved(false);
-                }}
-              />
-            ) : (
-              <SoftwareComplianceWith
-                softwareComplianceData={item.bbDetails}
-              />
-            )}
-          </SoftwareDetails>
-        ))
-        : null}
+          ? softwareDetail[0].compliance.map((item, indexKey) => (
+            <SoftwareDetails
+              title={format('app.compliance_with.label')}
+              complianceSection={true}
+              softwareVersion={item.softwareVersion}
+              softwareId={softwareDetail[0].compliance[indexKey]._id} // Pass the correct ID for each compliance item
+              key={`software-compliance-with-${indexKey}`}
+              viewReportDetails={true}
+            >
+              {isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1 ? (
+                <ComplianceDetailTable
+                  data={softwareDetailsDataToApprove}
+                  handleOpenEvaluationSchemaModal={(value) =>
+                    setDisplayEvaluationSchemaModal(value)
+                  }
+                  setUpdatedData={(data) => {
+                    setUpdatedData(data);
+                    setIsFormSaved(false);
+                  }}
+                />
+              ) : (
+                <SoftwareComplianceWith
+                  softwareComplianceData={item.bbDetails}
+                />
+              )}
+            </SoftwareDetails>
+          ))
+          : null}
 
       </div>
       {(isLoggedIn && softwareDetail.length && softwareDetail[0].status === 1) &&


### PR DESCRIPTION
**Ticket:**
https://govstack-global.atlassian.net/browse/TECH-1054

**Changes:**
- if there is more than one draft then newest description of draft will be displayed
- building blocks will be listed for each version instead of one (as it was done before)
- list of reports IDs is stored instead of one inconsistent ID, each is handled properly with "view reports details" buttons

**Consistent description:**
![Screenshot from 2024-06-11 16-19-06](https://github.com/GovStackWorkingGroup/testing-webapp/assets/56487722/c987b684-b219-443c-bd54-d9706c847865)

**Handles each form:**
![Screenshot from 2024-06-11 16-19-13](https://github.com/GovStackWorkingGroup/testing-webapp/assets/56487722/a679c811-38e7-461a-a9a9-771ba804686d)
![Screenshot from 2024-06-11 16-19-18](https://github.com/GovStackWorkingGroup/testing-webapp/assets/56487722/62ec70b5-6318-42f7-b292-21adb3f5638d)


**How was it tested?**
1. Page display is now consistent and returns proper description every time
2. Empirical tests with 50 request on backend and aditional 30 on FE always provided the same result with latest software description