### PR TITLE
TECH-1061: added configuration for expiration time

### DIFF
--- a/backend/src/config/index.ts
+++ b/backend/src/config/index.ts
@@ -2,7 +2,7 @@
 import dotenv from 'dotenv';
 import { MongoConnection } from './connectionStringBuilder';
 import rateLimit from "express-rate-limit"; 
-
+import { parseDuration } from './utils';
 dotenv.config();
 
 interface AppConfig {
@@ -61,7 +61,9 @@ const appConfig: AppConfig = {
   appName: process.env.appName || 'testing-webapp-api',
   isProduction: process.env.envName ? process.env.envName === 'prod' : false,
   mongoConnection: new MongoConnection(),
-  draftExpirationTime: 7 * 24 * 60 * 60 * 1000, // 7 days
+  draftExpirationTime: process.env.DRAFT_EXPIRATION_TIME 
+    ? parseDuration(process.env.DRAFT_EXPIRATION_TIME) 
+    : 7 * 24 * 60 * 60 * 1000,
   frontendHost: process.env.FE_HOST,
   cron: {
     removeExpiredDraftsSchedule: '0 3 * * 0', // Run every Sunday at 3:00 AM

--- a/backend/src/config/utils.ts
+++ b/backend/src/config/utils.ts
@@ -2,7 +2,7 @@
 
 const parseDuration = (duration: string) => {
     const [days, hours, minutes, seconds, milliseconds] = duration.split('*').map(Number);
-    return (days || 1) * (hours || 1) * (minutes || 1) * (seconds || 1) * (milliseconds || 1);
+    return (days || 1) * (hours || 24) * (minutes || 60) * (seconds || 60) * (milliseconds || 1000);
   };
 
 export {

--- a/backend/src/config/utils.ts
+++ b/backend/src/config/utils.ts
@@ -1,0 +1,10 @@
+/* eslint-disable import/prefer-default-export */
+
+const parseDuration = (duration: string) => {
+    const [days, hours, minutes, seconds, milliseconds] = duration.split('*').map(Number);
+    return (days || 1) * (hours || 1) * (minutes || 1) * (seconds || 1) * (milliseconds || 1);
+  };
+
+export {
+  parseDuration,
+};


### PR DESCRIPTION
**Ticket:**
https://govstack-global.atlassian.net/browse/TECH-1061

**Changes:**
- time expiration is not configurable
- user can enter number in milliseconds in format like it was before: 7 * 24 * 60 * 60 * 1000, // 7 days
- user can provide only days and it will calculate it to proper milliseconds

**Notes:**
There was already proper handling by backend that sends error response message "Draft has expired" but it is not displayed for user. It will be handled in FE PR.