### PR TITLE
TECH-1056: status is now displayed for each cross-cutting, functional and interface requirement

### DIFF
--- a/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
+++ b/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
@@ -36,6 +36,7 @@ class KeyDigitalFunctionalitiesExtractor {
 
         let index = startIndex + 1;
         let hasList = false;
+        const keyDigitalFunctionalitiesStatus = "(REQUIRED)";
 
         while (index < nodes.length) {
             const node = nodes[index];
@@ -58,7 +59,10 @@ class KeyDigitalFunctionalitiesExtractor {
         }
 
         if (!hasList && contentUnderHeading.length > 0) {
-            requirements.push({ status: 0, requirement: contentUnderHeading.join(' ').trim() });
+            requirements.push({
+                status: 0,
+                requirement: `${keyDigitalFunctionalitiesStatus} ${contentUnderHeading.join(' ').trim()}`
+            });
         }
     }
 

--- a/backend/src/services/gitBookService/PageContentManager.ts
+++ b/backend/src/services/gitBookService/PageContentManager.ts
@@ -160,11 +160,17 @@ class GitBookPageContentManager {
 
     processTextForRequirement(text, requirements) {
         // Remove leading numeric sequences like "number.number.number"
-        text = text.replace(/^\d+\.\d+(\.\d+)?\s*/, '').trim();
+        const sanitizedText = text.replace(/^\d+\.\d+(\.\d+)?\s*/, '').trim();
+        
         let status = this.extractStatus(text);
         if (status !== undefined) {
-            text = text.replace(/\(REQUIRED\)|\(RECOMMENDED\)|\(OPTIONAL\)/, '').trim()+".";
-            requirements.push({ status, requirement: text });
+            const regex = /\((REQUIRED|RECOMMENDED|OPTIONAL)\)/;
+            const match = sanitizedText.match(regex);
+            const textReqRecOpt = match ? match[0] : '';
+            const modifiedText = sanitizedText.replace(regex, '').trim();
+            const finalText = textReqRecOpt + ' ' + modifiedText + ".";
+
+            requirements.push({ status, requirement: finalText });
         }
     }
 


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-1056

Changes:
- status of each ticket is not trimmed
- interface, cross-cutting and functional requirements has their status always on the start of the text
- KDF has always status (REQUIRED) on the start


Testing:
![Screenshot from 2024-06-13 16-04-30](https://github.com/GovStackWorkingGroup/testing-webapp/assets/56487722/6d13fe87-b485-40ee-b5f4-c4ef52d215f8)
