### PR TITLE
TECH-1047: Add placeholder text to empty assessment entries

### DIFF
--- a/frontend/components/compliance/ReportViewDetail.tsx
+++ b/frontend/components/compliance/ReportViewDetail.tsx
@@ -87,6 +87,7 @@ const ReportViewDetail = () => {
       const data = await getSoftwareDetailsReport(softwareId as string);
       if (data.status) {
         setSoftwareDetailsData(data.data);
+
       }
     }
   };
@@ -154,14 +155,14 @@ const ReportViewDetail = () => {
             </Link>
           </div>
         )}
-        {activeTab === 'interface' && (
+        {activeTab === 'interface' && softwareDetailsData !== undefined && (
           <SelectBBs
             interfaceRequirementsData={requirementsData}
             readOnlyView={true}
             readOnlyData={softwareDetailsData}
           />
         )}
-        {activeTab === 'specification' && (
+        {activeTab === 'specification' && softwareDetailsData !== undefined && (
           <RequirementSpecificationSelectBBs
             interfaceRequirementsData={requirementsData}
             readOnlyView={true}

--- a/frontend/components/shared/combined/RequirementSpecificationSelectBB.tsx
+++ b/frontend/components/shared/combined/RequirementSpecificationSelectBB.tsx
@@ -477,7 +477,7 @@ const RequirementSpecificationSelectBBs = ({
           handleSetOptions={handleSetOptions}
         />
       )}
-      {selectedItems.length > 0 && (
+      {selectedItems.length > 0 ? (
         <div>
           <div className="pills-container">
             {readOnlyView ? (
@@ -496,6 +496,11 @@ const RequirementSpecificationSelectBBs = ({
             {displayPills}
           </div>
           {displayTable}
+        </div>
+      ) : (
+        <div>
+          {format('app.view_report_details.noInformation',
+            { section: `${format('table.requirement_specification_compliance.label')}` })}
         </div>
       )}
     </div>

--- a/frontend/components/shared/combined/SelectBBs.tsx
+++ b/frontend/components/shared/combined/SelectBBs.tsx
@@ -410,7 +410,7 @@ const SelectBBs = ({
           handleSetOptions={handleSetOptions}
         />
       )}
-      {selectedItems.length > 0 && (
+      {selectedItems.length > 0 ? (
         <div>
           <div className="pills-container">
             {readOnlyView ? (
@@ -428,6 +428,11 @@ const SelectBBs = ({
             {displayPills}
           </div>
           {displayTable}
+        </div>
+      ) : (
+        <div>
+          {format('app.view_report_details.noInformation',
+            { section: `${format('table.interface_compliance.label')}` })}
         </div>
       )}
     </div>

--- a/frontend/translations/en.ts
+++ b/frontend/translations/en.ts
@@ -45,6 +45,7 @@ export const en = {
   'app.software_requirements_compliance.label':
     'Software Requirements Compliance',
   'app.view_report_details.label': 'View report details',
+  'app.view_report_details.noInformation': 'Information has not been provided for the {section} of the compliance form',
 
   'building_block.label': 'Building Block',
   'building_block.plural.label': 'Building Blocks',


### PR DESCRIPTION
Ticket: https://govstack-global.atlassian.net/browse/TECH-1047

Changes: 

- Added placeholder to tabs with no content
- Fixed when refreshing details showed no content