### PR TITLE
TECH-1089: added default and custom static pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       build:
         context: ./frontend
         dockerfile: ./Dockerfile
+      volumes:
+      - ./content/custom:/opt/app/content/custom
       ports:
         - 3003:3003
       environment:

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -41,6 +41,8 @@ next-env.d.ts
 # Deployment .env file
 deployment/.env
 
+# Static pages
+content/custom/
 
 */.env.example
 */.env

--- a/frontend/content/template/data-protection-notice.html
+++ b/frontend/content/template/data-protection-notice.html
@@ -1,0 +1,5 @@
+<main class='description-main-container'>
+    This page is currently a template. To populate it with content, 
+    manual updates in the IDE are required. If you are seeing this message and 
+    believe it is an error, please contact the site administrator for assistance.
+</main>

--- a/frontend/content/template/imprint.html
+++ b/frontend/content/template/imprint.html
@@ -1,0 +1,5 @@
+<main class='description-main-container'>
+    This page is currently a template. To populate it with content, 
+    manual updates in the IDE are required. If you are seeing this message and 
+    believe it is an error, please contact the site administrator for assistance.
+</main>

--- a/frontend/pages/data-protection-notice/index.tsx
+++ b/frontend/pages/data-protection-notice/index.tsx
@@ -1,23 +1,33 @@
-import Head from 'next/head';
+import fs from 'fs';
+import path from 'path';
+import { GetStaticProps } from 'next';
 import React from 'react';
-import Link from 'next/link';
-import useTranslations from '../../hooks/useTranslation';
 
-const SoftwareComplianceTestingPage = () => {
-  const { format } = useTranslations();
+interface DataProtectionNoticeProps {
+  content: string;
+}
 
-  return (
-    <div>
-      <Head>
-        <title>GovStack testing</title>
-        <meta name="description" content="GovStack Testing App"/>
-        <link rel="icon" href="/favicon.png"/>
-      </Head>
-      <main className='description-main-container'>
-        <p>{format('app.page_description_template')}</p>
-      </main>
-    </div>
-  );
+const DataProtectionNotice: React.FC<DataProtectionNoticeProps> = ({ content }) => {
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
 };
 
-export default SoftwareComplianceTestingPage;
+export const getStaticProps: GetStaticProps = async () => {
+  const customPath = path.join(process.cwd(), 'content', 'custom', 'data-protection-notice.html');
+  const templatePath = path.join(process.cwd(), 'content', 'template', 'data-protection-notice.html');
+
+  let contentPath = templatePath;
+
+  if (fs.existsSync(customPath)) {
+    contentPath = customPath;
+  }
+
+  const content = fs.readFileSync(contentPath, 'utf8');
+
+  return {
+    props: {
+      content,
+    },
+  };
+};
+
+export default DataProtectionNotice;

--- a/frontend/pages/imprint/index.tsx
+++ b/frontend/pages/imprint/index.tsx
@@ -1,22 +1,40 @@
-import Head from 'next/head';
+import fs from 'fs';
+import path from 'path';
+import { GetStaticProps } from 'next';
 import React from 'react';
-import useTranslations from '../../hooks/useTranslation';
 
-const SoftwareComplianceTestingPage = () => {
-  const { format } = useTranslations();
+interface ImprintProps {
+  content: string;
+}
 
-  return (
-    <div>
-      <Head>
-        <title>GovStack testing</title>
-        <meta name="description" content="GovStack Testing App" />
-        <link rel="icon" href="/favicon.png" />
-      </Head>
-      <main className='description-main-container'>
-        <p>{format('app.page_description_template')}</p>
-      </main>
-    </div>
-  );
+const Imprint: React.FC<ImprintProps> = ({ content }) => {
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
 };
 
-export default SoftwareComplianceTestingPage;
+export const getStaticProps: GetStaticProps = async () => {
+  const customPath = path.join(process.cwd(), 'content', 'custom', 'imprint.html');
+  const templatePath = path.join(process.cwd(), 'content', 'template', 'imprint.html');
+
+  let contentPath = templatePath;
+
+  if (fs.existsSync(customPath)) {
+    contentPath = customPath;
+  }
+
+  let content: string;
+
+  try {
+    content = fs.readFileSync(contentPath, 'utf8');
+  } catch (error: any) {
+    content = '<div>Content not available.</div>';
+    console.error(`Error reading file: ${error.message}`);
+  }
+
+  return {
+    props: {
+      content,
+    },
+  };
+};
+
+export default Imprint;


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-1089

Changes:
- docker now stores custom static pages
- pages displays custom context, and if it is not provided then default template

Test:
1. Locally worked for custom/default pages before and after rebuilding containers.