### PR TITLE
TECH-1104: trimmed empty characters from the end of softwarename

### DIFF
--- a/backend/src/db/repositories/complianceRepository.ts
+++ b/backend/src/db/repositories/complianceRepository.ts
@@ -98,7 +98,9 @@ const mongoComplianceRepository: ComplianceDbRepository = {
       const isDraft = draftData.status == StatusEnum.DRAFT;
       const uniqueId = isDraft ? uuidv4() : '';
       const expirationDate = isDraft ? new Date(Date.now() + appConfig.draftExpirationTime) : undefined;
-
+      if (draftData.softwareName) {
+        draftData.softwareName = draftData.softwareName.trim();
+      }
       const newForm = new Compliance({
         ...draftData,
         uniqueId,


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-1104

Changes:
- empty characters are trimmed form the end of the software name

How was it tested?
Locally created name with input: "333              ". Server correctly created softwareName with proper name "333".
![Screenshot from 2024-08-22 16-17-13](https://github.com/user-attachments/assets/e99d8386-9b56-433d-9d95-2a23f8300c68)
![Screenshot from 2024-08-22 16-17-20](https://github.com/user-attachments/assets/22a904cb-f4ac-4467-ba1b-f2a26cafb4a5)
![Screenshot from 2024-08-22 16-17-39](https://github.com/user-attachments/assets/5b515b84-fc0a-49d5-bd9f-ba0f713d6aba)


