### PR TITLE
TECH-1100: logo file is limited up to 1MB, added toast message

### DIFF
--- a/backend/src/middlewares/fileUpload.ts
+++ b/backend/src/middlewares/fileUpload.ts
@@ -25,7 +25,11 @@ export const createFileUploadMiddleware = () => {
         },
     });
 
-    return multer({ storage }).fields([
+    const limits = {
+        fileSize: 1 * 1024 * 1024, // 1 MB
+    };
+
+    return multer({ storage, limits }).fields([
         { name: 'logo', maxCount: 1 },
         { name: 'deploymentCompliance[documentation]', maxCount: 1 },
         { name: 'deploymentCompliance[deploymentInstructions]', maxCount: 1 },

--- a/frontend/components/form/SoftwareComplianceForm.tsx
+++ b/frontend/components/form/SoftwareComplianceForm.tsx
@@ -140,9 +140,10 @@ const SoftwareComplianceForm = ({
           localStorage.removeItem(SOFTWARE_ATTRIBUTES_STORAGE_NAME);
           setIsDraftSaved(true);
           nextStepRef.current?.goNext();
+
           return;
         }
-  
+
         if (response.error?.status === 413) {
           toast.error(format('form.file_size_error.message'), {
             icon: <RiErrorWarningFill className="error-toast-icon" />,
@@ -153,6 +154,7 @@ const SoftwareComplianceForm = ({
           });
         }
       });
+
       return;
     }
 
@@ -163,15 +165,16 @@ const SoftwareComplianceForm = ({
             icon: <RiCheckboxCircleFill className="success-toast-icon" />,
           });
           localStorage.removeItem(SOFTWARE_ATTRIBUTES_STORAGE_NAME);
-  
+
           router.replace({
             query: { draftUUID: response.data.uniqueId, formStep: 2 },
           });
           setIsDraftSaved(true);
           nextStepRef.current?.goNext();
+
           return;
         }
-  
+
         if (response.error?.status === 413) {
           toast.error(format('form.file_size_error.message'), {
             icon: <RiErrorWarningFill className="error-toast-icon" />,

--- a/frontend/components/form/SoftwareComplianceForm.tsx
+++ b/frontend/components/form/SoftwareComplianceForm.tsx
@@ -132,28 +132,27 @@ const SoftwareComplianceForm = ({
   const handleSaveDraft = async (softwareData: FormValuesType) => {
     setSoftwareVersion(softwareData.softwareVersion.value);
     if (draftUUID) {
-      await updateDraftDetailsStepOne(draftUUID as string, softwareData).then(
-        (response) => {
-          if (response.status) {
-            toast.success(format('form.form_saved_success.message'), {
-              icon: <RiCheckboxCircleFill className="success-toast-icon" />,
-            });
-            localStorage.removeItem(SOFTWARE_ATTRIBUTES_STORAGE_NAME);
-
-            setIsDraftSaved(true);
-            nextStepRef.current?.goNext();
-
-            return;
-          }
-
-          if (!response.status) {
-            toast.error(format('form.form_saved_error.message'), {
-              icon: <RiErrorWarningFill className="error-toast-icon" />,
-            });
-          }
+      await updateDraftDetailsStepOne(draftUUID as string, softwareData).then((response) => {
+        if (response.status) {
+          toast.success(format('form.form_saved_success.message'), {
+            icon: <RiCheckboxCircleFill className="success-toast-icon" />,
+          });
+          localStorage.removeItem(SOFTWARE_ATTRIBUTES_STORAGE_NAME);
+          setIsDraftSaved(true);
+          nextStepRef.current?.goNext();
+          return;
         }
-      );
-
+  
+        if (response.error?.status === 413) {
+          toast.error(format('form.file_size_error.message'), {
+            icon: <RiErrorWarningFill className="error-toast-icon" />,
+          });
+        } else {
+          toast.error(response.error?.message || format('form.form_saved_error.message'), {
+            icon: <RiErrorWarningFill className="error-toast-icon" />,
+          });
+        }
+      });
       return;
     }
 
@@ -164,19 +163,21 @@ const SoftwareComplianceForm = ({
             icon: <RiCheckboxCircleFill className="success-toast-icon" />,
           });
           localStorage.removeItem(SOFTWARE_ATTRIBUTES_STORAGE_NAME);
-
-          // router.replace only here because draftUUID is undefined
+  
           router.replace({
             query: { draftUUID: response.data.uniqueId, formStep: 2 },
           });
           setIsDraftSaved(true);
           nextStepRef.current?.goNext();
-
           return;
         }
-
-        if (!response.status) {
-          toast.error(format('form.form_saved_error.message'), {
+  
+        if (response.error?.status === 413) {
+          toast.error(format('form.file_size_error.message'), {
+            icon: <RiErrorWarningFill className="error-toast-icon" />,
+          });
+        } else {
+          toast.error(response.error?.message || format('form.form_saved_error.message'), {
             icon: <RiErrorWarningFill className="error-toast-icon" />,
           });
         }

--- a/frontend/service/serviceAPI.ts
+++ b/frontend/service/serviceAPI.ts
@@ -18,7 +18,8 @@ import {
   SubmitDraftResponseType,
   SubmittingFormResponseType,
   FilterOptionsType,
-  ListFilters
+  ListFilters,
+  FormErrorResponseType
 } from './types';
 
 export const baseUrl = process.env.API_URL;
@@ -237,7 +238,7 @@ export const getSoftwareDetails = async (softwareName: string) => {
     });
 };
 
-export const saveSoftwareDraft = async (software: FormValuesType) => {
+export const saveSoftwareDraft = async (software: FormValuesType): Promise<{ data?: POSTSoftwareAttributesType; error?: FormErrorResponseType; status: boolean }> => {
   const formData = new FormData();
   formData.append('softwareName', software.softwareName.value);
   formData.append('logo', software.softwareLogo.value as File);
@@ -249,21 +250,28 @@ export const saveSoftwareDraft = async (software: FormValuesType) => {
   formData.append('compliance[0][version]', software.softwareVersion.value);
 
   return await fetch(`${baseUrl}/compliance/drafts`, {
-    method: 'post',
+    method: 'POST',
     body: formData,
   })
     .then((response) => {
       if (!response.ok) {
-        throw new Error(response.statusText);
-      }
+        const errorMessage = response.status === 413
+          ? 'The logo file size exceeds the 1 MB limit. Please upload a smaller file.'
+          : response.statusText || 'An error occurred while saving the draft.';
 
+        const error: FormErrorResponseType = { status: response.status, name: 'CustomError', message: errorMessage };
+        throw error;
+      }
       return response.json();
     })
     .then<Success<POSTSoftwareAttributesType>>((response) => {
       return { data: response, status: true };
     })
-    .catch<Failure>((error) => {
-      return { error, status: false };
+    .catch((error: FormErrorResponseType) => {
+      return {
+        error,
+        status: false,
+      };
     });
 };
 
@@ -314,7 +322,7 @@ export const getComplianceRequirements = async () => {
 export const updateDraftDetailsStepOne = async (
   draftUUID: string,
   data: FormValuesType
-) => {
+): Promise<{ data?: POSTSoftwareAttributesType; error?: FormErrorResponseType; status: boolean }> => {
   const formData = new FormData();
 
   formData.append('softwareName', data.softwareName.value);
@@ -331,16 +339,23 @@ export const updateDraftDetailsStepOne = async (
   })
     .then((response) => {
       if (!response.ok) {
-        throw new Error(response.statusText);
-      }
+        const errorMessage = response.status === 413
+          ? 'The logo file size exceeds the 1 MB limit. Please upload a smaller file.'
+          : response.statusText || 'An error occurred while updating the draft.';
 
+        const error: FormErrorResponseType = { status: response.status, name: 'CustomError', message: errorMessage };
+        throw error;
+      }
       return response.json();
     })
-    .then<Success<POSTSoftwareAttributesType>>((actualData) => {
-      return { data: actualData, status: true };
+    .then<Success<POSTSoftwareAttributesType>>((response) => {
+      return { data: response, status: true };
     })
-    .catch<Failure>((error) => {
-      return { error, status: false };
+    .catch((error: FormErrorResponseType) => {
+      return {
+        error,
+        status: false,
+      };
     });
 };
 

--- a/frontend/service/types.ts
+++ b/frontend/service/types.ts
@@ -278,6 +278,12 @@ export type SubmitDraftResponseType = {
   link: string;
 };
 
+export type FormErrorResponseType = {
+  status: number;
+  name: string;
+  message: string;
+};
+
 type FormBBDetails = {
   interface: { level: number; note: string };
   deployment: { level: number; note: string };

--- a/frontend/translations/en.ts
+++ b/frontend/translations/en.ts
@@ -56,7 +56,7 @@ export const en = {
 
   'drag_drop.doc_format.label':
     'PDF, word document or plain text files accepted.',
-  'drag_drop.image_format.label': 'PNG, JPG or SVG files accepted.',
+  'drag_drop.image_format.label': 'PNG, JPG or SVG files accepted. Maximum size: 1 MB.',
   'drag_drop.or_drop.label': 'or drag and drop it here',
   'drag_drop.select_file.label': 'Select a file to upload',
 
@@ -124,6 +124,7 @@ export const en = {
     'Invalid file format. Please select a PNG, JPG, or SVG file.',
   'form.link.label': 'Link',
   'form.required_field.message': 'This field is required.',
+  'form.file_size_error.message': 'The file size exceeds the limit.',
   'form.form_accepted_success.message': 'Form accepted successfully',
   'form.form_accepted_error.message': 'Form accepting failed',
   'form.form_reject_success.message': 'Form rejected successfully',


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-1100

Changes:
- logo is limited to 1MB
- translation is added with information that logo is 1MB
- toast message with proper info is displayed when logo is too large
- updated handleSaveDraft and saveSoftwareDraft functions

How was it tested?
Manually tested it creating a draft with too large logo.