### PR TITLE
TECH-1100: FE validation for files error handling

### DIFF
--- a/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
+++ b/backend/src/services/gitBookService/KeyDigitalFunctionalitiesExtractor.ts
@@ -9,7 +9,7 @@ class GitBookPageManagerError extends Error {
 }
 
 class KeyDigitalFunctionalitiesExtractor {
-    private static readonly DEFAULT_REQUIREMENT_STATUS = "(REQUIRED)";
+    private static readonly DEFAULT_REQUIREMENT_STATUS = "";
 
     extractKeyDigitalFunctionalitiesRequirements(pageContent: any, spaceID, requirementURL, bbKey) {
         if (!pageContent?.document?.nodes) {

--- a/frontend/components/form/SoftwareAttributesForm.tsx
+++ b/frontend/components/form/SoftwareAttributesForm.tsx
@@ -199,7 +199,6 @@ const SoftwareAttributesForm = ({
     }));
   };
 
-
   const isFormValid = (values: FormValuesType): boolean => {
     const updatedValues = { ...values };
     const entries = Object.entries(updatedValues);

--- a/frontend/components/form/helpers.tsx
+++ b/frontend/components/form/helpers.tsx
@@ -1,6 +1,6 @@
 export const softwareAttributesDefaultValues = {
   softwareName: { value: '', error: false },
-  softwareLogo: { value: undefined, error: false },
+  softwareLogo: { value: undefined, error: { error: false, message: '' } },
   softwareWebsite: { value: '', error: { error: false, message: '' } },
   softwareDocumentation: { value: '', error: { error: false, message: '' } },
   toolDescription: { value: '', error: false },

--- a/frontend/components/shared/DragAndDrop.tsx
+++ b/frontend/components/shared/DragAndDrop.tsx
@@ -25,7 +25,7 @@ const allowedFormatsDocx = [
   'text/plain',
 ];
 
-const MAX_FILE_SIZE = parseInt(process.env.REACT_APP_MAX_FILE_SIZE || `${1 * 1024 * 1024}`, 10); // Default to 1 MB in bytes 
+const MAX_FILE_SIZE = parseInt(process.env.REACT_APP_MAX_FILE_SIZE || `${1 * 1024 * 1024}`, 10); // Default to 1 MB in bytes
 
 const DragDrop = ({
   selectedFile,

--- a/frontend/translations/en.ts
+++ b/frontend/translations/en.ts
@@ -122,6 +122,8 @@ export const en = {
     'Invalid file format. Please select a PDF, word document, or plain text file.',
   'form.invalid_image_file_format.message':
     'Invalid file format. Please select a PNG, JPG, or SVG file.',
+  'form.invalid_file_size.message': 'Maximum file size is {size} MB. Please upload a smaller file.',
+  'form.no_file_selected.message': 'No file selected. Please choose a file to upload.',
   'form.link.label': 'Link',
   'form.required_field.message': 'This field is required.',
   'form.file_size_error.message': 'The file size exceeds the limit.',


### PR DESCRIPTION
Ticket:
https://govstack-global.atlassian.net/browse/TECH-1100
https://govstack-global.atlassian.net/browse/TECH-1092

Changes:
- for missing logo new error is introduced 'No file selected. Please choose a file to upload.' instead of info that the field is required
- introduce validation for file size
- simplified validation for types and size, allowing to extend it in the future if needed
- too large file is not being saved in the storage

How was it tested?
- when file is no selected and user tries to save:
![Screenshot from 2024-11-14 16-06-38](https://github.com/user-attachments/assets/530d352e-ac2d-4da1-bcf1-a76bfc96590c)
- when file is too large:
![Screenshot from 2024-11-14 16-07-14](https://github.com/user-attachments/assets/51fc89d8-205f-4496-9182-296a0c99900a)
- when file is in wrong format:
![Screenshot from 2024-11-14 16-07-32](https://github.com/user-attachments/assets/cecab1b1-d49b-4b0e-afbb-aae69db003a6)
- other uploads are not affected:
![Screenshot from 2024-11-14 16-08-22](https://github.com/user-attachments/assets/4cd73cf8-66e6-4415-9419-8086906cc354)

